### PR TITLE
Prevent non-admin links and handle message edits

### DIFF
--- a/src/events/general/onMessage.ts
+++ b/src/events/general/onMessage.ts
@@ -1,41 +1,11 @@
 import { Events, Message } from 'discord.js';
+import { moderateMessage } from '../../services/moderationService';
 
 const event: TrackerEvent<Events.MessageCreate> = {
-	type: Events.MessageCreate,
-	async execute(_, message: Message) {
-		// Check if the message is from a bot or not in a guild
-		if (message.author.bot || !message.guild) return;
-
-		// Define patterns to match invites and IPs
-		const inviteRegex = /(discord\.(gg|io|me|li|com|net)\/[^\s]+)/g;
-		const ipRegex = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
-
-		// Check if the message contains any invite or IP
-		if (
-			inviteRegex.test(message.content) ||
-			ipRegex.test(message.content)
-		) {
-			await message.delete();
-			return;
-		}
-
-		// Extract and check URLs in the message content
-		const urls = message.content.match(/\bhttps?:\/\/\S+/gi);
-		if (urls) {
-			const allLinksAreClean: boolean = urls.every((url: string) => {
-				try {
-					return new URL(url).hostname.endsWith('mctracker.ir');
-				} catch (error) {
-					// Ignore invalid URLs
-					return true;
-				}
-			});
-
-			if (! allLinksAreClean) {
-				await message.delete();
-			}
-		}
-	},
+    type: Events.MessageCreate,
+    async execute(_, message: Message) {
+        await moderateMessage(message);
+    },
 };
 
 export default event;

--- a/src/events/general/onMessageUpdate.ts
+++ b/src/events/general/onMessageUpdate.ts
@@ -1,0 +1,19 @@
+import { Events, Message, PartialMessage } from 'discord.js';
+import { moderateMessage } from '../../services/moderationService';
+
+const event: TrackerEvent<Events.MessageUpdate> = {
+    type: Events.MessageUpdate,
+    async execute(_oldMessage: Message | PartialMessage, newMessage: Message | PartialMessage) {
+        if (newMessage.partial) {
+            try {
+                newMessage = await newMessage.fetch();
+            } catch {
+                return;
+            }
+        }
+
+        await moderateMessage(newMessage as Message);
+    },
+};
+
+export default event;

--- a/src/services/moderationService.ts
+++ b/src/services/moderationService.ts
@@ -1,0 +1,38 @@
+import { Message, PermissionFlagsBits, TextChannel, ThreadChannel } from 'discord.js';
+
+export async function moderateMessage(message: Message): Promise<void> {
+    if (message.author.bot || !message.guild) return;
+
+    const channel = message.channel;
+    if (
+        (channel instanceof TextChannel || channel instanceof ThreadChannel) &&
+        channel.name.startsWith('ticket-')
+    ) {
+        return;
+    }
+
+    if (message.member?.permissions.has(PermissionFlagsBits.Administrator)) return;
+
+    const inviteRegex = /(?:https?:\/\/)?(?:www\.)?discord(?:\.gg|\.io|\.me|\.li|\.com|\.net)\/[^\s]+/i;
+    const ipRegex = /\b(?:\d{1,3}\.){3}\d{1,3}\b/;
+
+    if (inviteRegex.test(message.content) || ipRegex.test(message.content)) {
+        await message.delete();
+        return;
+    }
+
+    const urls = message.content.match(/\bhttps?:\/\/\S+/gi);
+    if (urls) {
+        const allLinksAreClean: boolean = urls.every((url: string) => {
+            try {
+                return new URL(url).hostname.endsWith('mctracker.ir');
+            } catch {
+                return true;
+            }
+        });
+
+        if (!allLinksAreClean) {
+            await message.delete();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Centralize message moderation to exempt admins and channels named `ticket-*`
- Delete messages that are edited or sent with unauthorized links

------
https://chatgpt.com/codex/tasks/task_b_68a9e9e01430832988fb14d6a9afd5f0